### PR TITLE
Issue 15 colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img src="https://spotify-cards.up.railway.app/api?id=05iALOptaNoV3EmXnxz1IJ&color=A0C3D2" />
 </p>
 
-A unofficial open-source Spotify PromoCards API built to serve Song Cards. For more information on using this API, see <a href="https://spotify-cards.up.railway.app/">Docs</a>
+An unofficial open-source Spotify PromoCards API built to serve Song Cards. For more information on using this API, see <a href="https://spotify-cards.up.railway.app/">Docs</a>
 
 # Table of contents
 

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ async function getAverageColor(img) {
 }
 
 // Function, Name, Color
-async function searchTracksbyName(name, color, orientation, res) {
+async function searchTracksbyName(name, color, orientation, res, colorGiven) {
     let totalArtist;
     let artistList = [];
     let artistString = '';
@@ -151,7 +151,7 @@ async function searchTracksbyName(name, color, orientation, res) {
 
     const canvas = createCanvas(width, height);
     const context = canvas.getContext('2d');
-    if (color === "#000") {
+    if (!colorGiven) {
         const image = await loadImage(imageURL)
         color = await getAverageColor(image)
     }
@@ -205,7 +205,7 @@ async function searchTracksbyName(name, color, orientation, res) {
 
 
 // Function ID, Color 
-async function searchTracksbyID(id, color, orientation, res) {
+async function searchTracksbyID(id, color, orientation, res, colorGiven) {
     let totalArtist;
     let artistList = [];
     let artistString = '';
@@ -288,7 +288,7 @@ async function searchTracksbyID(id, color, orientation, res) {
 
     const canvas = createCanvas(width, height);
     const context = canvas.getContext('2d');
-    if (color === "#000") {
+    if (!colorGiven) {
         const image = await loadImage(imageURL)
         color = await getAverageColor(image)
     }
@@ -478,7 +478,8 @@ app.get('/', (req, res) => {
 
 // API
 app.get('/api', (req, res) => {
-    let imageColor = '#000';
+    let imageColor;
+    let colorGiven = req.query.color != null;
     let songName = req.query.name;
     let songID = req.query.id;
     let orientation = req.query.orientation;
@@ -489,9 +490,9 @@ app.get('/api', (req, res) => {
         orientation = "landscape"
     }
     if (songName != null && songID == null){
-        searchTracksbyName(songName, imageColor, orientation, res);
+        searchTracksbyName(songName, imageColor, orientation, res, colorGiven);
     } else if (songID != null && songName == null) {
-        searchTracksbyID(songID, imageColor, orientation, res);
+        searchTracksbyID(songID, imageColor, orientation, res, colorGiven);
     } else {
         res.send('name or id not provided or both provided instead of one')
     }

--- a/index.js
+++ b/index.js
@@ -489,7 +489,9 @@ app.get('/api', (req, res) => {
     if (orientation === null || !["landscape", "square"].includes(orientation)) {
         orientation = "landscape"
     }
-    if (songName != null && songID == null){
+    if (colorGiven && (!isHexCode(req.query.color))) {
+        res.send('given hex is not valid, make sure not to add # at start');
+    } else if (songName != null && songID == null){
         searchTracksbyName(songName, imageColor, orientation, res, colorGiven);
     } else if (songID != null && songName == null) {
         searchTracksbyID(songID, imageColor, orientation, res, colorGiven);
@@ -502,3 +504,16 @@ app.get('/api', (req, res) => {
 app.listen(port, () => {
     console.log(`app listening at http://localhost:${port}`)
 });
+
+isHexCode = function (hex) {
+    allowedChars = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'A', 'B', 'C', 'D', 'E', 'F'];
+    if (hex.length != 3 && hex.length != 6) {
+        return false;
+    }
+    for (let i = 0; i < hex.length; i++) {
+        if (!allowedChars.includes(hex[i])) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/index.js
+++ b/index.js
@@ -417,7 +417,7 @@ function textWrap(text, max, min, maxWidth, ctx, x, y, fontPre, fontPost) {
                         if (currentLineWidth < maxWidth) {
                             secondLine += " " + word;
                         } else {
-                            text = firstLine + " " + secondLine
+                            text = firstLine + " " + secondLine + "...";
                             break;
                         }
                     }
@@ -461,7 +461,7 @@ function textWrap(text, max, min, maxWidth, ctx, x, y, fontPre, fontPost) {
                 } else {
                     ctx.fillText(firstLine, x, y);
                     secondLine = words.slice(_).join(" ");
-                    ctx.fillText(secondLine + "...", x, y + currentFontSize);
+                    ctx.fillText(secondLine, x, y + currentFontSize);
                     return currentFontSize;
                 }
             }

--- a/index.js
+++ b/index.js
@@ -95,9 +95,13 @@ async function searchTracksbyName(name, color, orientation, res) {
         songNameX = 560
         songNameY = 250
         songFont = "bold 100px"
+        songFontMax = "100"
+        songFontMin = "70"
         songArtistX = 560
         songArtistY = 380
         songArtistFont = "bold 40px"
+        songArtistFontMax = "40"
+        songArtistFontMin = "30"
         bottomTextX = 805
         bottomTextY = 542
         bottomTextFont = "20px"
@@ -162,12 +166,23 @@ async function searchTracksbyName(name, color, orientation, res) {
         var ctext = text.split("").join(String.fromCharCode(8202))
         context.fillText(ctext, songX, songY)
     }
-    context.font = `${songFont} GothamBold`
-    context.fillText(songName, songNameX, songNameY)
+    if (orientation === "landscape") {
+        // textWrap returns the downward shift that next element has to undergo
+        songArtistY += textWrap(songName, songFontMax, songFontMin, 580, context, songNameX, songNameY, "bold ", "px GothamBold");
+    } else {
+        context.font = `${songFont} GothamBold`
+        context.fillText(songName, songNameX, songNameY)
+    }
 
-    context.font = `${songArtistFont} GothamBook`
     artistString = artistList.join(", ")
-    context.fillText(artistString, songArtistX, songArtistY)
+    if (orientation === "landscape") {
+        let downShift = textWrap(artistString, songArtistFontMax, songArtistFontMin, 500, context, songArtistX, songArtistY, "bold ", "px GothamBook");
+        bottomTextY += downShift;
+        dmY += downShift;
+    } else {
+        context.font = `${songArtistFont} GothamBook`
+        context.fillText(artistString, songArtistX, songArtistY)
+    }
 
     context.font = `${bottomTextFont} GothamBold`
     var cbottomText = bottomText.split("").join(String.fromCharCode(8202))
@@ -214,9 +229,13 @@ async function searchTracksbyID(id, color, orientation, res) {
         songNameX = 560
         songNameY = 250
         songFont = "bold 100px"
+        songFontMax = "100"
+        songFontMin = "70"
         songArtistX = 560
         songArtistY = 380
         songArtistFont = "bold 40px"
+        songArtistFontMax = "40"
+        songArtistFontMin = "30"
         bottomTextX = 805
         bottomTextY = 542
         bottomTextFont = "20px"
@@ -284,12 +303,22 @@ async function searchTracksbyID(id, color, orientation, res) {
         var ctext = text.split("").join(String.fromCharCode(8202))
         context.fillText(ctext, songX, songY)
     }
-    context.font = `${songFont} GothamBold`
-    context.fillText(songName, songNameX, songNameY)
+    if (orientation === "landscape") {
+        songArtistY += textWrap(songName, songFontMax, songFontMin, 580, context, songNameX, songNameY, "bold ", "px GothamBold");
+    } else {
+        context.font = `${songFont} GothamBold`
+        context.fillText(songName, songNameX, songNameY)
+    }
 
-    context.font = `${songArtistFont} GothamBook`
     artistString = artistList.join(", ")
-    context.fillText(artistString, songArtistX, songArtistY)
+    if (orientation === "landscape") {
+        let downShift = textWrap(artistString, songArtistFontMax, songArtistFontMin, 500, context, songArtistX, songArtistY, "bold ", "px GothamBook");
+        bottomTextY += downShift;
+        dmY += downShift;
+    } else {
+        context.font = `${songArtistFont} GothamBook`
+        context.fillText(artistString, songArtistX, songArtistY)
+    }
 
     context.font = `${bottomTextFont} GothamBold`
     var cbottomText = bottomText.split("").join(String.fromCharCode(8202))
@@ -310,6 +339,136 @@ async function searchTracksbyID(id, color, orientation, res) {
     })
 }
 
+function textWrap(text, max, min, maxWidth, ctx, x, y, fontPre, fontPost) {
+    let currentFontSize;
+    for(currentFontSize = parseInt(max); currentFontSize >= parseInt(min); currentFontSize--) {
+        ctx.font = fontPre + currentFontSize + fontPost;
+        let currentWidth = ctx.measureText(text).width;
+        if (currentWidth < maxWidth) {
+            break;
+        }
+    }
+
+    if (currentFontSize >= parseInt(min)) {
+        // we have found an appropriate font size for 1 line
+        ctx.fillText(text, x, y);
+        return 0;
+    } else {
+        // even the shortest font size is overflowing for 1 line
+
+        for (currentFontSize = parseInt(max); currentFontSize >= parseInt(min); currentFontSize--) {
+            let tobreak = false;
+            ctx.font = fontPre + currentFontSize + fontPost;
+
+            let words = text.split(" ");
+            firstLine = words[0];
+            for (let _ = 1; _ < words.length; _++) {
+                let word = words[_];
+                let currentLineWidth = ctx.measureText(firstLine + " " + word).width;
+                if (currentLineWidth < maxWidth) {
+                    firstLine += " " + word;
+                } else {
+                    words = words.splice(_);
+                    secondLine = words.join(" ");
+                    if (ctx.measureText(secondLine).width < maxWidth) {
+                        tobreak = true;
+                    }
+                    break;
+                }
+            }
+            if(tobreak) {
+                break;
+            }
+        }
+
+        if (currentFontSize >= parseInt(min)) {
+            // found an appropriate font size for 2 lines
+            ctx.font = fontPre + currentFontSize + fontPost;
+            let words = text.split(" ");
+            firstLine = words[0];
+            for (let _ = 1; _ < words.length; _++) {
+                let word = words[_];
+                let currentLineWidth = ctx.measureText(firstLine + " " + word).width;
+                if (currentLineWidth < maxWidth) {
+                    firstLine += " " + word;
+                } else {
+                    ctx.fillText(firstLine, x, y);
+                    secondLine = words.slice(_).join(" ");
+                    ctx.fillText(secondLine, x, y + currentFontSize);
+                    return currentFontSize;
+                }
+            }
+        } else {
+            // need to remove some words
+            let words = text.split(" ");
+            firstLine = words[0];
+            ctx.font = fontPre + min + fontPost;
+            for (let _ = 1; _ < words.length; _++) {
+                let word = words[_];
+                let currentLineWidth = ctx.measureText(firstLine + " " + word).width;
+                if (currentLineWidth < maxWidth) {
+                    firstLine += " " + word;
+                } else {
+                    words = words.splice(_);
+                    secondLine = words[0];
+                    for (let __ = 1; __ < words.length; __++) {
+                        let word = words[__];
+                        let currentLineWidth = ctx.measureText(secondLine + " " + word).width;
+                        if (currentLineWidth < maxWidth) {
+                            secondLine += " " + word;
+                        } else {
+                            text = firstLine + " " + secondLine
+                            break;
+                        }
+                    }
+                    break;
+                }
+            }
+
+            for (currentFontSize = parseInt(max); currentFontSize >= parseInt(min); currentFontSize--) {
+                let tobreak = false;
+                ctx.font = fontPre + currentFontSize + fontPost;
+    
+                let words = text.split(" ");
+                firstLine = words[0];
+                for (let _ = 1; _ < words.length; _++) {
+                    let word = words[_];
+                    let currentLineWidth = ctx.measureText(firstLine + " " + word).width;
+                    if (currentLineWidth < maxWidth) {
+                        firstLine += " " + word;
+                    } else {
+                        words = words.splice(_);
+                        secondLine = words.join(" ");
+                        if (ctx.measureText(secondLine).width < maxWidth) {
+                            tobreak = true;
+                        }
+                        break;
+                    }
+                }
+                if(tobreak) {
+                    break;
+                }
+            }
+
+            ctx.font = fontPre + currentFontSize + fontPost;
+            words = text.split(" ");
+            firstLine = words[0];
+            for (let _ = 1; _ < words.length; _++) {
+                let word = words[_];
+                let currentLineWidth = ctx.measureText(firstLine + " " + word).width;
+                if (currentLineWidth < maxWidth) {
+                    firstLine += " " + word;
+                } else {
+                    ctx.fillText(firstLine, x, y);
+                    secondLine = words.slice(_).join(" ");
+                    ctx.fillText(secondLine + "...", x, y + currentFontSize);
+                    return currentFontSize;
+                }
+            }
+        }
+    }
+}
+
 // Index
 app.get('/', (req, res) => {
     // Currently Only Song Name
@@ -326,7 +485,6 @@ app.get('/api', (req, res) => {
     if (req.query.color != null){
         imageColor = '#' + req.query.color
     }
-    console.log(orientation)
     if (orientation === null || !["landscape", "square"].includes(orientation)) {
         orientation = "landscape"
     }

--- a/public/index.html
+++ b/public/index.html
@@ -132,21 +132,20 @@
           *Results can differ as there can be another song with the Same Name
         </p>
         <code>https://spotify-cards.up.railway.app/api?name={song
-            name}&color={color hex without #}</code>
+            name}</code>
         <br />
         <br />
         <p class="fw-bold fs-6">Example</p>
-        <code>https://spotify-cards.up.railway.app/api?name=Silver%20Lining&color=A0C3D2</code>
+        <code>https://spotify-cards.up.railway.app/api?name=Silver%20Lining</code>
         <hr />
         <p class="fw-bold fs-3">
           By Song Track ID <span class="lead fs-3">(Recommended)</span>
         </p>
-        <code>https://spotify-cards.up.railway.app/api?id={song id}&color={color
-            hex without #}</code>
+        <code>https://spotify-cards.up.railway.app/api?id={song id}</code>
         <br />
         <br />
         <p class="fw-bold fs-6">Example</p>
-        <code>https://spotify-cards.up.railway.app/api?id=05iALOptaNoV3EmXnxz1IJ&color=A0C3D2</code>
+        <code>https://spotify-cards.up.railway.app/api?id=05iALOptaNoV3EmXnxz1IJ</code>
         <br />
         <br />
         <p class="fw-bold fs-6">How to get Spotify Song Track ID?</p>
@@ -159,6 +158,17 @@
             The ID after <code>spotify:track:</code> is the Spotify Song Track ID
           </li>
         </ul>
+        <hr />
+        <p class="fw-bolder fs-2">Color</p>
+        <hr />
+        <p class="fw-light">
+          Type hex code without #. If not specified, the best color corresponding to the song image will be used.
+        </p>
+        <code>https://spotify-cards.up.railway.app/api?id={song id}&color={color hex without #}</code>
+        <br />
+        <br />
+        <p class="fw-bold fs-6">Example</p>
+        <code>https://spotify-cards.up.railway.app/api?id=05iALOptaNoV3EmXnxz1IJ&color=A0C3D2</code>
         <hr />
         <p class="fw-bolder fs-2">Orientation</p>
         <hr />

--- a/public/index.html
+++ b/public/index.html
@@ -156,7 +156,7 @@
             Right Click >> Share (Keep Ctrl Pressed) >> Copy Spotify URI
           </li>
           <li>
-            The ID after <code>spotify:</code> is the Spotify Song Track ID
+            The ID after <code>spotify:track:</code> is the Spotify Song Track ID
           </li>
         </ul>
         <hr />


### PR DESCRIPTION
Closes #15.

- [x] Remove the use #000 as a flag.

----

- [ ] Add support for hex code with # too.
- [ ] Remove the line from docs that asks to use hex code without #.

These two cannot be done because of this reason: In any URL, the part after `#` is treated as an id, and the page is scrolled to the element with that id, if it exists. It is done by the browser, and that part of the URL is not sent to the server.

----

- [x] Show a message if the given hex code is not valid.
- [x] Update docs to add information about automatically using the best-suited color according to the image, if the color property is not in the request.