### PR TITLE
Issue 15 hex code

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ async function getAverageColor(img) {
 }
 
 // Function, Name, Color
-async function searchTracksbyName(name, color, orientation, res) {
+async function searchTracksbyName(name, color, orientation, res, colorGiven) {
     let totalArtist;
     let artistList = [];
     let artistString = '';
@@ -147,7 +147,7 @@ async function searchTracksbyName(name, color, orientation, res) {
 
     const canvas = createCanvas(width, height);
     const context = canvas.getContext('2d');
-    if (color === "#000") {
+    if (!colorGiven) {
         const image = await loadImage(imageURL)
         color = await getAverageColor(image)
     }
@@ -190,7 +190,7 @@ async function searchTracksbyName(name, color, orientation, res) {
 
 
 // Function ID, Color 
-async function searchTracksbyID(id, color, orientation, res) {
+async function searchTracksbyID(id, color, orientation, res, colorGiven) {
     let totalArtist;
     let artistList = [];
     let artistString = '';
@@ -269,7 +269,7 @@ async function searchTracksbyID(id, color, orientation, res) {
 
     const canvas = createCanvas(width, height);
     const context = canvas.getContext('2d');
-    if (color === "#000") {
+    if (!colorGiven) {
         const image = await loadImage(imageURL)
         color = await getAverageColor(image)
     }
@@ -319,7 +319,8 @@ app.get('/', (req, res) => {
 
 // API
 app.get('/api', (req, res) => {
-    let imageColor = '#000';
+    let imageColor;
+    let colorGiven = req.query.color != null;
     let songName = req.query.name;
     let songID = req.query.id;
     let orientation = req.query.orientation;
@@ -331,9 +332,9 @@ app.get('/api', (req, res) => {
         orientation = "landscape"
     }
     if (songName != null && songID == null){
-        searchTracksbyName(songName, imageColor, orientation, res);
+        searchTracksbyName(songName, imageColor, orientation, res, colorGiven);
     } else if (songID != null && songName == null) {
-        searchTracksbyID(songID, imageColor, orientation, res);
+        searchTracksbyID(songID, imageColor, orientation, res, colorGiven);
     } else {
         res.send('name or id not provided or both provided instead of one')
     }

--- a/index.js
+++ b/index.js
@@ -331,7 +331,9 @@ app.get('/api', (req, res) => {
     if (orientation === null || !["landscape", "square"].includes(orientation)) {
         orientation = "landscape"
     }
-    if (songName != null && songID == null){
+    if (colorGiven && (!isHexCode(req.query.color))) {
+        res.send('given hex is not valid, make sure not to add # at start');
+    } else if (songName != null && songID == null){
         searchTracksbyName(songName, imageColor, orientation, res, colorGiven);
     } else if (songID != null && songName == null) {
         searchTracksbyID(songID, imageColor, orientation, res, colorGiven);
@@ -344,3 +346,16 @@ app.get('/api', (req, res) => {
 app.listen(port, () => {
     console.log(`app listening at http://localhost:${port}`)
 });
+
+isHexCode = function (hex) {
+    allowedChars = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'A', 'B', 'C', 'D', 'E', 'F'];
+    if (hex.length != 3 && hex.length != 6) {
+        return false;
+    }
+    for (let i = 0; i < hex.length; i++) {
+        if (!allowedChars.includes(hex[i])) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -132,21 +132,20 @@
           *Results can differ as there can be another song with the Same Name
         </p>
         <code>https://spotify-cards.up.railway.app/api?name={song
-            name}&color={color hex without #}</code>
+          name}</code>
         <br />
         <br />
         <p class="fw-bold fs-6">Example</p>
-        <code>https://spotify-cards.up.railway.app/api?name=Silver%20Lining&color=A0C3D2</code>
+        <code>https://spotify-cards.up.railway.app/api?name=Silver%20Lining</code>
         <hr />
         <p class="fw-bold fs-3">
           By Song Track ID <span class="lead fs-3">(Recommended)</span>
         </p>
-        <code>https://spotify-cards.up.railway.app/api?id={song id}&color={color
-            hex without #}</code>
+        <code>https://spotify-cards.up.railway.app/api?id={song id}</code>
         <br />
         <br />
         <p class="fw-bold fs-6">Example</p>
-        <code>https://spotify-cards.up.railway.app/api?id=05iALOptaNoV3EmXnxz1IJ&color=A0C3D2</code>
+        <code>https://spotify-cards.up.railway.app/api?id=05iALOptaNoV3EmXnxz1IJ</code>
         <br />
         <br />
         <p class="fw-bold fs-6">How to get Spotify Song Track ID?</p>
@@ -159,6 +158,17 @@
             The ID after <code>spotify:track:</code> is the Spotify Song Track ID
           </li>
         </ul>
+        <hr />
+        <p class="fw-bolder fs-2">Color</p>
+        <hr />
+        <p class="fw-light">
+          Type hex code without #. If not specified, the best color corresponding to the song image will be used.
+        </p>
+        <code>https://spotify-cards.up.railway.app/api?id={song id}&color={color hex without #}</code>
+        <br />
+        <br />
+        <p class="fw-bold fs-6">Example</p>
+        <code>https://spotify-cards.up.railway.app/api?id=05iALOptaNoV3EmXnxz1IJ&color=A0C3D2</code>
         <hr />
         <p class="fw-bolder fs-2">Orientation</p>
         <hr />

--- a/public/index.html
+++ b/public/index.html
@@ -156,7 +156,7 @@
             Right Click >> Share (Keep Ctrl Pressed) >> Copy Spotify URI
           </li>
           <li>
-            The ID after <code>spotify:</code> is the Spotify Song Track ID
+            The ID after <code>spotify:track:</code> is the Spotify Song Track ID
           </li>
         </ul>
         <hr />


### PR DESCRIPTION
Closes #15.

- [x] Remove the use #000 as a flag.

----

- [ ] Add support for hex code with # too.
- [ ] Remove the line from docs that asks to use hex code without #.

These two cannot be done because of this reason: In any URL, the part after `#` is treated as an id, and the page is scrolled to the element with that id, if it exists. It is done by the browser, and that part of the URL is not sent to the server.

----

- [x] Show a message if the given hex code is not valid.
- [x] Update docs to add information about automatically using the best-suited color according to the image, if the color property is not in the request.